### PR TITLE
Add sync functionality

### DIFF
--- a/automerge-persistent-localstorage/Cargo.toml
+++ b/automerge-persistent-localstorage/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
-automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
 automerge-persistent = { path = "../automerge-persistent" }
 web-sys = { version = "0.3.50", features = ["Storage"] }
 serde = "1.0.125"

--- a/automerge-persistent-localstorage/Cargo.toml
+++ b/automerge-persistent-localstorage/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
-automerge-protocol = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
 automerge-persistent = { path = "../automerge-persistent" }
 web-sys = { version = "0.3.50", features = ["Storage"] }
 serde = "1.0.125"

--- a/automerge-persistent-localstorage/src/lib.rs
+++ b/automerge-persistent-localstorage/src/lib.rs
@@ -144,7 +144,7 @@ impl automerge_persistent::Persister for LocalStoragePersister {
         Ok(())
     }
 
-    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn get_sync_state(&self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.sync_states.get(peer_id).cloned())
     }
 
@@ -170,6 +170,10 @@ impl automerge_persistent::Persister for LocalStoragePersister {
             )
             .map_err(LocalStoragePersisterError::StorageError)?;
         Ok(())
+    }
+
+    fn get_peer_ids(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
+        Ok(self.sync_states.keys().cloned().collect())
     }
 }
 

--- a/automerge-persistent-localstorage/src/lib.rs
+++ b/automerge-persistent-localstorage/src/lib.rs
@@ -159,9 +159,9 @@ impl automerge_persistent::Persister for LocalStoragePersister {
         Ok(())
     }
 
-    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error> {
-        for id in &peer_ids {
-            self.sync_states.remove(id);
+    fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error> {
+        for id in peer_ids {
+            self.sync_states.remove(*id);
         }
         self.storage
             .set_item(

--- a/automerge-persistent-sled/Cargo.toml
+++ b/automerge-persistent-sled/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
-automerge-protocol = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
 automerge-persistent = { path = "../automerge-persistent" }
 sled = "0.34.6"
 thiserror = "1.0.24"

--- a/automerge-persistent-sled/Cargo.toml
+++ b/automerge-persistent-sled/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
-automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
 automerge-persistent = { path = "../automerge-persistent" }
 sled = "0.34.6"
 thiserror = "1.0.24"

--- a/automerge-persistent-sled/benches/save.rs
+++ b/automerge-persistent-sled/benches/save.rs
@@ -9,6 +9,7 @@ fn small_backend_apply_local_change(c: &mut Criterion) {
                 let sled = automerge_persistent_sled::SledPersister::new(
                     db.open_tree("changes").unwrap(),
                     db.open_tree("document").unwrap(),
+                    db.open_tree("sync_states").unwrap(),
                     "".to_owned(),
                 );
                 let backend = automerge_persistent::PersistentBackend::load(sled).unwrap();
@@ -40,6 +41,7 @@ fn small_backend_apply_local_change_flush(c: &mut Criterion) {
                 let sled = automerge_persistent_sled::SledPersister::new(
                     db.open_tree("changes").unwrap(),
                     db.open_tree("document").unwrap(),
+                    db.open_tree("sync_states").unwrap(),
                     "".to_owned(),
                 );
                 let backend = automerge_persistent::PersistentBackend::load(sled).unwrap();
@@ -74,6 +76,7 @@ fn small_backend_apply_changes(c: &mut Criterion) {
                 let sled = automerge_persistent_sled::SledPersister::new(
                     db.open_tree("changes").unwrap(),
                     db.open_tree("document").unwrap(),
+                    db.open_tree("sync_states").unwrap(),
                     "".to_owned(),
                 );
                 let mut other_backend = automerge::Backend::init();
@@ -111,6 +114,7 @@ fn small_backend_compact(c: &mut Criterion) {
                 let sled = automerge_persistent_sled::SledPersister::new(
                     db.open_tree("changes").unwrap(),
                     db.open_tree("document").unwrap(),
+                    db.open_tree("sync_states").unwrap(),
                     "".to_owned(),
                 );
                 let mut backend = automerge_persistent::PersistentBackend::load(sled).unwrap();

--- a/automerge-persistent-sled/benches/save.rs
+++ b/automerge-persistent-sled/benches/save.rs
@@ -129,10 +129,10 @@ fn small_backend_compact(c: &mut Criterion) {
                         Ok(())
                     })
                     .unwrap();
-                let (_patch, _change) = backend.apply_local_change(change.unwrap()).unwrap();
+                let _patch = backend.apply_local_change(change.unwrap()).unwrap();
                 backend
             },
-            |mut persistent_doc| persistent_doc.compact(),
+            |mut persistent_doc| persistent_doc.compact(&[]),
             criterion::BatchSize::SmallInput,
         )
     });

--- a/automerge-persistent-sled/src/lib.rs
+++ b/automerge-persistent-sled/src/lib.rs
@@ -165,7 +165,7 @@ impl automerge_persistent::Persister for SledPersister {
         Ok(())
     }
 
-    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn get_sync_state(&self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let sync_state_key = self.make_peer_key(peer_id);
         Ok(self
             .sync_states_tree
@@ -185,5 +185,13 @@ impl automerge_persistent::Persister for SledPersister {
             self.sync_states_tree.remove(key)?;
         }
         Ok(())
+    }
+
+    fn get_peer_ids(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
+        self.sync_states_tree
+            .scan_prefix(&self.prefix)
+            .keys()
+            .map(|v| v.map(|v| v.to_vec()).map_err(Self::Error::SledError))
+            .collect()
     }
 }

--- a/automerge-persistent-sled/src/lib.rs
+++ b/automerge-persistent-sled/src/lib.rs
@@ -179,8 +179,8 @@ impl automerge_persistent::Persister for SledPersister {
         Ok(())
     }
 
-    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error> {
-        for id in &peer_ids {
+    fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error> {
+        for id in peer_ids {
             let key = self.make_peer_key(id);
             self.sync_states_tree.remove(key)?;
         }

--- a/automerge-persistent-sled/src/lib.rs
+++ b/automerge-persistent-sled/src/lib.rs
@@ -127,7 +127,7 @@ impl automerge_persistent::Persister for SledPersister {
     /// Get all of the current changes.
     fn get_changes(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
         self.changes_tree
-            .iter()
+            .scan_prefix(&self.prefix)
             .values()
             .map(|v| v.map(|v| v.to_vec()).map_err(Self::Error::SledError))
             .collect()

--- a/automerge-persistent-sled/src/lib.rs
+++ b/automerge-persistent-sled/src/lib.rs
@@ -13,8 +13,14 @@
 //! let db = sled::Config::new().temporary(true).open()?;
 //! let changes_tree = db.open_tree("changes")?;
 //! let documents_tree = db.open_tree("documents")?;
+//! let sync_states_tree = db.open_tree("sync-states")?;
 //!
-//! let persister = SledPersister::new(changes_tree, documents_tree, String::new());
+//! let persister = SledPersister::new(
+//!     changes_tree,
+//!     documents_tree,
+//!     sync_states_tree,
+//!     String::new(),
+//! );
 //! let backend = PersistentBackend::load(persister);
 //! # Ok(())
 //! # }
@@ -29,12 +35,22 @@
 //! let db = sled::Config::new().temporary(true).open()?;
 //! let changes_tree = db.open_tree("changes")?;
 //! let documents_tree = db.open_tree("documents")?;
+//! let sync_states_tree = db.open_tree("sync-states")?;
 //!
-//! let persister1 =
-//!     SledPersister::new(changes_tree.clone(), documents_tree.clone(), "1".to_owned());
+//! let persister1 = SledPersister::new(
+//!     changes_tree.clone(),
+//!     documents_tree.clone(),
+//!     sync_states_tree.clone(),
+//!     "1".to_owned(),
+//! );
 //! let backend1 = PersistentBackend::load(persister1);
 //!
-//! let persister2 = SledPersister::new(changes_tree, documents_tree, "2".to_owned());
+//! let persister2 = SledPersister::new(
+//!     changes_tree,
+//!     documents_tree,
+//!     sync_states_tree,
+//!     "2".to_owned(),
+//! );
 //! let backend2 = PersistentBackend::load(persister2);
 //! # Ok(())
 //! # }
@@ -54,6 +70,7 @@ const DOCUMENT_KEY: &[u8] = b"document";
 pub struct SledPersister {
     changes_tree: sled::Tree,
     document_tree: sled::Tree,
+    sync_states_tree: sled::Tree,
     prefix: String,
 }
 
@@ -67,10 +84,16 @@ pub enum SledPersisterError {
 
 impl SledPersister {
     /// Construct a new persister.
-    pub fn new(changes_tree: sled::Tree, document_tree: sled::Tree, prefix: String) -> Self {
+    pub fn new(
+        changes_tree: sled::Tree,
+        document_tree: sled::Tree,
+        sync_states_tree: sled::Tree,
+        prefix: String,
+    ) -> Self {
         Self {
             changes_tree,
             document_tree,
+            sync_states_tree,
             prefix,
         }
     }
@@ -88,6 +111,12 @@ impl SledPersister {
     fn make_document_key(&self) -> Vec<u8> {
         let mut key = self.prefix.as_bytes().to_vec();
         key.extend(DOCUMENT_KEY);
+        key
+    }
+
+    fn make_peer_key(&self, peer_id: &[u8]) -> Vec<u8> {
+        let mut key = self.prefix.as_bytes().to_vec();
+        key.extend(peer_id);
         key
     }
 }
@@ -133,6 +162,28 @@ impl automerge_persistent::Persister for SledPersister {
     /// Set the document in the tree.
     fn set_document(&mut self, data: Vec<u8>) -> Result<(), Self::Error> {
         self.document_tree.insert(self.make_document_key(), data)?;
+        Ok(())
+    }
+
+    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let sync_state_key = self.make_peer_key(peer_id);
+        Ok(self
+            .sync_states_tree
+            .get(sync_state_key)?
+            .map(|v| v.to_vec()))
+    }
+
+    fn set_sync_state(&mut self, peer_id: Vec<u8>, sync_state: Vec<u8>) -> Result<(), Self::Error> {
+        let sync_state_key = self.make_peer_key(&peer_id);
+        self.sync_states_tree.insert(sync_state_key, sync_state)?;
+        Ok(())
+    }
+
+    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error> {
+        for id in &peer_ids {
+            let key = self.make_peer_key(id);
+            self.sync_states_tree.remove(key)?;
+        }
         Ok(())
     }
 }

--- a/automerge-persistent/Cargo.toml
+++ b/automerge-persistent/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
-automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
-automerge-backend = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
+automerge-backend = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
 thiserror = "1.0.24"

--- a/automerge-persistent/Cargo.toml
+++ b/automerge-persistent/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Jeffery <dev@jeffas.io>"]
 edition = "2018"
 
 [dependencies]
-automerge = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
-automerge-protocol = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
-automerge-backend = { git = "https://github.com/jeffa5/automerge-rs", branch = "main" }
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge-protocol = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
+automerge-backend = { git = "https://github.com/automerge/automerge-rs", branch = "sync" }
 thiserror = "1.0.24"

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -212,8 +212,8 @@ where
     /// pending changes.
     ///
     /// This may not give all hashes required as multiple changes in a sequence could be missing.
-    pub fn get_missing_deps(&self) -> Vec<ChangeHash> {
-        self.backend.get_missing_deps(&[])
+    pub fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
+        self.backend.get_missing_deps(heads)
     }
 
     /// Get the current heads of the hash graph (changes without successors).

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -73,7 +73,7 @@ pub trait Persister {
     fn set_sync_state(&mut self, peer_id: Vec<u8>, sync_state: Vec<u8>) -> Result<(), Self::Error>;
 
     /// Removes the sync states associated with the given peer_ids.
-    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error>;
+    fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error>;
 }
 
 /// Errors that persistent backends can return.
@@ -170,7 +170,7 @@ where
     /// in old_peers.
     pub fn compact(
         &mut self,
-        old_peer_ids: Vec<Vec<u8>>,
+        old_peer_ids: &[&[u8]],
     ) -> Result<(), PersistentBackendError<P::Error>> {
         let changes = self.backend.get_changes(&[]);
         let saved_backend = self.backend.save()?;

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -226,7 +226,8 @@ where
     /// Peer id is intentionally low level and up to the user as it can be a DNS name, IP address or
     /// something else.
     ///
-    /// This internally retrieves the previous sync state from storage and saves the new one after.
+    /// This internally retrieves the previous sync state from storage and saves the new one
+    /// afterwards.
     pub fn generate_sync_message(
         &mut self,
         peer_id: Vec<u8>,
@@ -255,7 +256,8 @@ where
     /// Peer id is intentionally low level and up to the user as it can be a DNS name, IP address or
     /// something else.
     ///
-    /// This internally retrieves the previous sync state from storage and saves the new one after.
+    /// This internally retrieves the previous sync state from storage and saves the new one
+    /// afterwards.
     pub fn receive_sync_message(
         &mut self,
         peer_id: Vec<u8>,

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -309,18 +309,16 @@ where
         peer_id: PeerId,
     ) -> Result<Option<SyncMessage>, PersistentBackendError<P::Error>> {
         if !self.sync_states.contains_key(&peer_id) {
-            let s = if let Some(sync_state) = self
+            if let Some(sync_state) = self
                 .persister
                 .get_sync_state(&peer_id)
                 .map_err(PersistentBackendError::PersisterError)?
             {
-                SyncState::decode(&sync_state)?
-            } else {
-                SyncState::default()
-            };
-            self.sync_states.insert(peer_id.clone(), s);
+                let s = SyncState::decode(&sync_state)?;
+                self.sync_states.insert(peer_id.clone(), s);
+            }
         }
-        let sync_state = self.sync_states.get_mut(&peer_id).unwrap();
+        let sync_state = self.sync_states.entry(peer_id.clone()).or_default();
         let message = self.backend.generate_sync_message(sync_state);
         self.persister
             .set_sync_state(
@@ -347,18 +345,16 @@ where
         message: SyncMessage,
     ) -> Result<Option<Patch>, PersistentBackendError<P::Error>> {
         if !self.sync_states.contains_key(&peer_id) {
-            let s = if let Some(sync_state) = self
+            if let Some(sync_state) = self
                 .persister
                 .get_sync_state(&peer_id)
                 .map_err(PersistentBackendError::PersisterError)?
             {
-                SyncState::decode(&sync_state)?
-            } else {
-                SyncState::default()
-            };
-            self.sync_states.insert(peer_id.clone(), s);
+                let s = SyncState::decode(&sync_state)?;
+                self.sync_states.insert(peer_id.clone(), s);
+            }
         }
-        let sync_state = self.sync_states.get_mut(&peer_id).unwrap();
+        let sync_state = self.sync_states.entry(peer_id.clone()).or_default();
         let patch = self
             .backend
             .receive_sync_message(sync_state, message)

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -64,7 +64,7 @@ pub trait Persister {
     ///
     /// A peer id corresponds to an instance of a backend and may be serving multiple frontends so
     /// we cannot have it work on ActorIds.
-    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+    fn get_sync_state(&self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Sets the sync state for the given peer.
     ///
@@ -74,6 +74,12 @@ pub trait Persister {
 
     /// Removes the sync states associated with the given peer_ids.
     fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error>;
+
+    /// Returns the list of peer ids with stored SyncStates.
+    ///
+    /// This is intended for use by users to see what peer_ids are taking space so that they can be
+    /// removed during a compaction.
+    fn get_peer_ids(&self) -> Result<Vec<Vec<u8>>, Self::Error>;
 }
 
 /// Errors that persistent backends can return.

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -149,7 +149,7 @@ where
     pub fn apply_local_change(
         &mut self,
         change: UncompressedChange,
-    ) -> Result<(Patch, Change), PersistentBackendError<P::Error>> {
+    ) -> Result<Patch, PersistentBackendError<P::Error>> {
         let (patch, change) = self.backend.apply_local_change(change)?;
         self.persister
             .insert_changes(vec![(
@@ -158,7 +158,7 @@ where
                 change.raw_bytes().to_vec(),
             )])
             .map_err(PersistentBackendError::PersisterError)?;
-        Ok((patch, change))
+        Ok(patch)
     }
 
     /// Compact the storage.

--- a/automerge-persistent/src/mem.rs
+++ b/automerge-persistent/src/mem.rs
@@ -50,7 +50,7 @@ impl Persister for MemoryPersister {
         Ok(())
     }
 
-    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn get_sync_state(&self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.sync_states.get(peer_id).cloned())
     }
 
@@ -64,5 +64,9 @@ impl Persister for MemoryPersister {
             self.sync_states.remove(*id);
         }
         Ok(())
+    }
+
+    fn get_peer_ids(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
+        Ok(self.sync_states.keys().cloned().collect())
     }
 }

--- a/automerge-persistent/src/mem.rs
+++ b/automerge-persistent/src/mem.rs
@@ -12,6 +12,7 @@ use crate::Persister;
 pub struct MemoryPersister {
     changes: HashMap<(ActorId, u64), Vec<u8>>,
     document: Option<Vec<u8>>,
+    sync_states: HashMap<Vec<u8>, Vec<u8>>,
 }
 
 impl Persister for MemoryPersister {
@@ -46,6 +47,22 @@ impl Persister for MemoryPersister {
     /// Set the document.
     fn set_document(&mut self, data: Vec<u8>) -> Result<(), Self::Error> {
         self.document = Some(data);
+        Ok(())
+    }
+
+    fn get_sync_state(&mut self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.sync_states.get(peer_id).cloned())
+    }
+
+    fn set_sync_state(&mut self, peer_id: Vec<u8>, sync_state: Vec<u8>) -> Result<(), Self::Error> {
+        self.sync_states.insert(peer_id, sync_state);
+        Ok(())
+    }
+
+    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error> {
+        for id in &peer_ids {
+            self.sync_states.remove(id);
+        }
         Ok(())
     }
 }

--- a/automerge-persistent/src/mem.rs
+++ b/automerge-persistent/src/mem.rs
@@ -59,9 +59,9 @@ impl Persister for MemoryPersister {
         Ok(())
     }
 
-    fn remove_sync_states(&mut self, peer_ids: Vec<Vec<u8>>) -> Result<(), Self::Error> {
-        for id in &peer_ids {
-            self.sync_states.remove(id);
+    fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error> {
+        for id in peer_ids {
+            self.sync_states.remove(*id);
         }
         Ok(())
     }


### PR DESCRIPTION
This needs to store sync states in the persisters.

The persistent backend also needs to keep these in memory to retain most of the information to maintain efficient syncs.