### PR TITLE
Add fs persistence layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
   "automerge-persistent",
   "automerge-persistent-sled",
   "automerge-persistent-localstorage",
+  "automerge-persistent-fs",
 ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Good backends to have would be:
 - [x] sled
 - [x] localstorage
 - [ ] indexeddb
-- [ ] filesystem
+- [x] filesystem
 - other suggestions welcome!
 
 ## Usage

--- a/automerge-persistent-fs/Cargo.toml
+++ b/automerge-persistent-fs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "automerge-persistent-fs"
+version = "0.1.0"
+authors = ["Andrew Jeffery <dev@jeffas.io>"]
+edition = "2018"
+
+[dependencies]
+automerge = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
+automerge-persistent = { path = "../automerge-persistent" }
+futures = "0.3"
+hex = "0.4.3"
+thiserror = "1.0.24"
+tokio = { version = "1", features = ["fs"] }

--- a/automerge-persistent-fs/Cargo.toml
+++ b/automerge-persistent-fs/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 [dependencies]
 automerge = { git = "https://github.com/automerge/automerge-rs", branch = "main" }
 automerge-persistent = { path = "../automerge-persistent" }
-futures = "0.3"
+futures = { version = "0.3", optional = true }
 hex = "0.4.3"
 thiserror = "1.0.24"
-tokio = { version = "1", features = ["fs"] }
+tokio = { version = "1", features = ["fs"], optional = true }
+
+[features]
+async = ["futures", "tokio"]

--- a/automerge-persistent-fs/src/lib.rs
+++ b/automerge-persistent-fs/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 use automerge::ActorId;
 use automerge_persistent::{Persister, StoredSizes};
+#[cfg(feature = "async")]
 use futures::{Future, FutureExt, TryStreamExt};
 use hex::FromHexError;
 
@@ -57,6 +58,7 @@ impl FsPersisterCache {
         Ok(flushed)
     }
 
+    #[cfg(feature = "async")]
     async fn flush_changes(&mut self, changes_path: PathBuf) -> Result<usize, std::io::Error> {
         let futs = futures::stream::FuturesUnordered::new();
         for ((a, s), c) in self.changes.drain() {
@@ -69,6 +71,7 @@ impl FsPersisterCache {
         Ok(res?.iter().sum())
     }
 
+    #[cfg(feature = "async")]
     async fn flush_document(&mut self, doc_path: PathBuf) -> Result<usize, std::io::Error> {
         let mut flushed = 0;
         if let Some(data) = self.document.take() {
@@ -78,6 +81,7 @@ impl FsPersisterCache {
         Ok(flushed)
     }
 
+    #[cfg(feature = "async")]
     async fn flush_sync_states(
         &mut self,
         sync_states_path: PathBuf,
@@ -94,6 +98,7 @@ impl FsPersisterCache {
         Ok(res?.iter().sum())
     }
 
+    #[cfg(feature = "async")]
     pub async fn flush(
         &mut self,
         doc_path: PathBuf,
@@ -187,6 +192,7 @@ impl FsPersister {
         Ok(s)
     }
 
+    #[cfg(feature = "async")]
     pub fn flush_cache(&mut self) -> impl Future<Output = Result<usize, std::io::Error>> {
         let doc_path = self.doc_path.clone();
         let changes_path = self.changes_path.clone();

--- a/automerge-persistent-fs/src/lib.rs
+++ b/automerge-persistent-fs/src/lib.rs
@@ -1,0 +1,358 @@
+use std::{
+    collections::HashMap,
+    fs,
+    os::unix::prelude::OsStrExt,
+    path::{Path, PathBuf},
+};
+
+use automerge::ActorId;
+use automerge_persistent::{Persister, StoredSizes};
+use futures::{Future, FutureExt, TryStreamExt};
+use hex::FromHexError;
+
+#[derive(Debug)]
+pub struct FsPersister {
+    changes_path: PathBuf,
+    doc_path: PathBuf,
+    sync_states_path: PathBuf,
+    cache: FsPersisterCache,
+    sizes: StoredSizes,
+}
+
+#[derive(Debug)]
+pub struct FsPersisterCache {
+    changes: HashMap<(ActorId, u64), Vec<u8>>,
+    document: Option<Vec<u8>>,
+    sync_states: HashMap<Vec<u8>, Vec<u8>>,
+}
+
+impl FsPersisterCache {
+    fn flush_changes_sync(&mut self, changes_path: PathBuf) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        for ((a, s), c) in self.changes.drain() {
+            fs::write(make_changes_path(&changes_path, &a, s), &c)?;
+            flushed += c.len();
+        }
+        Ok(flushed)
+    }
+
+    fn flush_document_sync(&mut self, doc_path: PathBuf) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        if let Some(data) = self.document.take() {
+            fs::write(&doc_path, &data)?;
+            flushed = data.len();
+        }
+        Ok(flushed)
+    }
+
+    fn flush_sync_states_sync(
+        &mut self,
+        sync_states_path: PathBuf,
+    ) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        for (peer_id, sync_state) in self.sync_states.drain() {
+            fs::write(make_peer_path(&sync_states_path, &peer_id), &sync_state)?;
+            flushed += sync_state.len();
+        }
+        Ok(flushed)
+    }
+
+    async fn flush_changes(&mut self, changes_path: PathBuf) -> Result<usize, std::io::Error> {
+        let futs = futures::stream::FuturesUnordered::new();
+        for ((a, s), c) in self.changes.drain() {
+            let len = c.len();
+            futs.push(
+                tokio::fs::write(make_changes_path(&changes_path, &a, s), c).map(move |_| Ok(len)),
+            );
+        }
+        let res: Result<Vec<usize>, std::io::Error> = futs.try_collect().await;
+        Ok(res?.iter().sum())
+    }
+
+    async fn flush_document(&mut self, doc_path: PathBuf) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        if let Some(data) = self.document.take() {
+            tokio::fs::write(&doc_path, &data).await?;
+            flushed = data.len();
+        }
+        Ok(flushed)
+    }
+
+    async fn flush_sync_states(
+        &mut self,
+        sync_states_path: PathBuf,
+    ) -> Result<usize, std::io::Error> {
+        let futs = futures::stream::FuturesUnordered::new();
+        for (peer_id, sync_state) in self.sync_states.drain() {
+            let len = sync_state.len();
+            futs.push(
+                tokio::fs::write(make_peer_path(&sync_states_path, &peer_id), sync_state)
+                    .map(move |_| Ok(len)),
+            );
+        }
+        let res: Result<Vec<usize>, std::io::Error> = futs.try_collect().await;
+        Ok(res?.iter().sum())
+    }
+
+    pub async fn flush(
+        &mut self,
+        doc_path: PathBuf,
+        changes_path: PathBuf,
+        sync_states_path: PathBuf,
+    ) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        flushed += self.flush_document(doc_path).await?;
+        flushed += self.flush_changes(changes_path).await?;
+        flushed += self.flush_sync_states(sync_states_path).await?;
+        Ok(flushed)
+    }
+
+    pub fn flush_sync(
+        &mut self,
+        doc_path: PathBuf,
+        changes_path: PathBuf,
+        sync_states_path: PathBuf,
+    ) -> Result<usize, std::io::Error> {
+        let mut flushed = 0;
+        flushed += self.flush_document_sync(doc_path)?;
+        flushed += self.flush_changes_sync(changes_path)?;
+        flushed += self.flush_sync_states_sync(sync_states_path)?;
+        Ok(flushed)
+    }
+
+    fn drain_clone(&mut self) -> Self {
+        Self {
+            changes: self.changes.drain().collect(),
+            document: self.document.take(),
+            sync_states: self.sync_states.drain().collect(),
+        }
+    }
+}
+
+/// Possible errors from persisting.
+#[derive(Debug, thiserror::Error)]
+pub enum FsPersisterError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Hex(#[from] FromHexError),
+}
+
+const CHANGES_DIR: &str = "changes";
+const DOC_FILE: &str = "doc";
+const SYNC_DIR: &str = "sync";
+
+impl FsPersister {
+    pub fn new<R: AsRef<Path>, P: AsRef<Path>>(
+        root: R,
+        prefix: P,
+    ) -> Result<Self, FsPersisterError> {
+        let root_path = root.as_ref().join(&prefix);
+        fs::create_dir_all(&root_path)?;
+
+        let changes_path = root_path.join(CHANGES_DIR);
+        if fs::metadata(&changes_path).is_err() {
+            fs::create_dir(&changes_path)?;
+        }
+
+        let doc_path = root_path.join(DOC_FILE);
+
+        let sync_states_path = root_path.join(SYNC_DIR);
+        if fs::metadata(&sync_states_path).is_err() {
+            fs::create_dir(&sync_states_path)?;
+        }
+
+        let mut s = Self {
+            changes_path,
+            doc_path,
+            sync_states_path,
+            cache: FsPersisterCache {
+                changes: HashMap::new(),
+                document: None,
+                sync_states: HashMap::new(),
+            },
+            sizes: StoredSizes::default(),
+        };
+
+        s.sizes.changes = s.get_changes()?.iter().map(Vec::len).sum();
+        s.sizes.document = s.get_document()?.unwrap_or_default().len();
+        s.sizes.sync_states = s
+            .get_peer_ids()?
+            .iter()
+            .map(|id| s.get_sync_state(id).map(|o| o.unwrap_or_default().len()))
+            .collect::<Result<Vec<usize>, _>>()?
+            .iter()
+            .sum();
+
+        Ok(s)
+    }
+
+    pub fn flush_cache(&mut self) -> impl Future<Output = Result<usize, std::io::Error>> {
+        let doc_path = self.doc_path.clone();
+        let changes_path = self.changes_path.clone();
+        let sync_states_path = self.sync_states_path.clone();
+        let mut cache = self.cache.drain_clone();
+        async move { cache.flush(doc_path, changes_path, sync_states_path).await }
+    }
+
+    pub fn load<R: AsRef<Path>, P: AsRef<Path>>(
+        root: R,
+        prefix: P,
+    ) -> Result<Option<Self>, FsPersisterError> {
+        if !root.as_ref().join(&prefix).exists() {
+            return Ok(None);
+        }
+        let doc = Self::new(root, prefix)?;
+        Ok(Some(doc))
+    }
+}
+
+fn make_changes_path<P: AsRef<Path>>(changes_path: P, actor_id: &ActorId, seq: u64) -> PathBuf {
+    changes_path
+        .as_ref()
+        .join(format!("{}-{}", actor_id.to_hex_string(), seq))
+}
+
+fn make_peer_path<P: AsRef<Path>>(sync_states_path: P, peer_id: &[u8]) -> PathBuf {
+    sync_states_path.as_ref().join(hex::encode(peer_id))
+}
+
+impl Persister for FsPersister {
+    type Error = FsPersisterError;
+
+    fn get_changes(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
+        fs::read_dir(&self.changes_path)?
+            .filter_map(|entry| {
+                if let Ok((Ok(file_type), path)) =
+                    entry.map(|entry| (entry.file_type(), entry.path()))
+                {
+                    if file_type.is_file() {
+                        Some(fs::read(path).map_err(FsPersisterError::from))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn insert_changes(&mut self, changes: Vec<(ActorId, u64, Vec<u8>)>) -> Result<(), Self::Error> {
+        for (a, s, c) in changes {
+            self.sizes.changes += c.len();
+            if let Some(old) = self.cache.changes.insert((a, s), c) {
+                self.sizes.changes -= old.len();
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_changes(&mut self, changes: Vec<(&ActorId, u64)>) -> Result<(), Self::Error> {
+        for (a, s) in changes {
+            if let Some(old) = self.cache.changes.remove(&(a.clone(), s)) {
+                // not flushed yet
+                self.sizes.changes -= old.len();
+                continue;
+            }
+
+            let path = make_changes_path(&self.changes_path, a, s);
+            if let Ok(meta) = fs::metadata(&path) {
+                if meta.is_file() {
+                    fs::remove_file(&path)?;
+                    self.sizes.changes -= meta.len() as usize;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_document(&self) -> Result<Option<Vec<u8>>, Self::Error> {
+        if let Some(ref doc) = self.cache.document {
+            return Ok(Some(doc.clone()));
+        }
+        if fs::metadata(&self.doc_path).is_ok() {
+            return Ok(fs::read(&self.doc_path).map(|v| if v.is_empty() { None } else { Some(v) })?);
+        }
+        Ok(None)
+    }
+
+    fn set_document(&mut self, data: Vec<u8>) -> Result<(), Self::Error> {
+        self.sizes.document = data.len();
+        self.cache.document = Some(data);
+        Ok(())
+    }
+
+    fn get_sync_state(&self, peer_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        if let Some(sync_state) = self.cache.sync_states.get(peer_id) {
+            return Ok(Some(sync_state.clone()));
+        }
+        let path = make_peer_path(&self.sync_states_path, peer_id);
+        if fs::metadata(&path).is_ok() {
+            return Ok(fs::read(&path).map(|v| if v.is_empty() { None } else { Some(v) })?);
+        }
+        Ok(None)
+    }
+
+    fn set_sync_state(&mut self, peer_id: Vec<u8>, sync_state: Vec<u8>) -> Result<(), Self::Error> {
+        self.sizes.sync_states += sync_state.len();
+        if let Some(old) = self.cache.sync_states.insert(peer_id, sync_state) {
+            self.sizes.sync_states -= old.len();
+        }
+        Ok(())
+    }
+
+    fn remove_sync_states(&mut self, peer_ids: &[&[u8]]) -> Result<(), Self::Error> {
+        for peer_id in peer_ids {
+            if let Some(old) = self.cache.sync_states.remove(*peer_id) {
+                // not flushed yet
+                self.sizes.sync_states -= old.len();
+                continue;
+            }
+            let path = make_peer_path(&self.sync_states_path, peer_id);
+            if let Ok(meta) = fs::metadata(&path) {
+                if meta.is_file() {
+                    fs::remove_file(&path)?;
+                    self.sizes.sync_states -= meta.len() as usize;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_peer_ids(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
+        fs::read_dir(&self.sync_states_path)?
+            .filter_map(|entry| {
+                if let Ok((Ok(file_type), path)) =
+                    entry.map(|entry| (entry.file_type(), entry.path()))
+                {
+                    if file_type.is_file() {
+                        Some(
+                            hex::decode(path.file_name().unwrap().as_bytes())
+                                .map_err(FsPersisterError::from),
+                        )
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn sizes(&self) -> StoredSizes {
+        self.sizes.clone()
+    }
+
+    fn flush(&mut self) -> Result<usize, Self::Error> {
+        self.cache
+            .drain_clone()
+            .flush_sync(
+                self.doc_path.clone(),
+                self.changes_path.clone(),
+                self.sync_states_path.clone(),
+            )
+            .map_err(FsPersisterError::from)
+    }
+}

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -357,11 +357,20 @@ where
         &self.persister
     }
 
+    /// Obtain a mut reference to the persister.
+    pub fn persister_mut(&mut self) -> &mut P {
+        &mut self.persister
+    }
+
     /// Reset the sync state for a peer.
     ///
     /// This is typically used when a peer disconnects, we need to reset the sync state for them as
     /// they may come back up with different state.
     pub fn reset_sync_state(&mut self, peer_id: &[u8]) {
-        self.sync_states.remove(peer_id);
+        if self.sync_states.remove(peer_id).is_some() {
+            if let Err(e) = self.persister.remove_sync_states(&[peer_id]) {
+                eprintln!("could not remove sync state for peer {:?}: {e}", peer_id);
+            }
+        }
     }
 }

--- a/automerge-persistent/src/lib.rs
+++ b/automerge-persistent/src/lib.rs
@@ -32,7 +32,7 @@ use std::{collections::HashMap, fmt::Debug};
 pub use autocommit::PersistentAutoCommit;
 use automerge::{
     sync,
-    transaction::{self, Transaction},
+    transaction::{CommitOptions, Failure, Success, Transaction},
     ApplyOptions, Automerge, AutomergeError, Change, OpObserver,
 };
 pub use mem::MemoryPersister;
@@ -60,6 +60,19 @@ pub enum Error<E> {
     PersisterError(E),
 }
 
+/// Errors that persistent backends can return after a transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionError<PE, E> {
+    /// A persister error.
+    #[error(transparent)]
+    PersisterError(PE),
+    /// A transaction error
+    #[error(transparent)]
+    TransactionError(#[from] Failure<E>),
+}
+
+pub type TransactionResult<O, E, PE> = Result<Success<O>, TransactionError<PE, E>>;
+
 type PeerId = Vec<u8>;
 
 /// A wrapper for a persister and an automerge document.
@@ -82,21 +95,73 @@ where
         &mut self.document
     }
 
-    pub fn transact<F: FnOnce(&mut Transaction) -> Result<O, E>, O, E>(
-        &mut self,
-        f: F,
-    ) -> transaction::Result<O, E> {
+    pub fn transact<F, O, E>(&mut self, f: F) -> TransactionResult<O, E, P::Error>
+    where
+        F: FnOnce(&mut Transaction) -> Result<O, E>,
+    {
         let result = self.document.transact(f)?;
+        if let Err(e) = self.after_transaction() {
+            return Err(TransactionError::PersisterError(e));
+        }
+        Ok(result)
+    }
+
+    fn after_transaction(&mut self) -> Result<(), P::Error> {
         if let Some(change) = self.document.get_last_local_change() {
-            // TODO: remove this unwrap and return the error
-            self.persister
-                .insert_changes(vec![(
+            self.persister.insert_changes(vec![(
+                change.actor_id().clone(),
+                change.seq,
+                change.raw_bytes().to_vec(),
+            )])?;
+        }
+        Ok(())
+    }
+
+    pub fn transact_with<'a, F, O, E, C, Obs>(
+        &mut self,
+        c: C,
+        f: F,
+    ) -> TransactionResult<O, E, P::Error>
+    where
+        F: FnOnce(&mut Transaction) -> Result<O, E>,
+        C: FnOnce(&O) -> CommitOptions<'a, Obs>,
+        Obs: 'a + OpObserver,
+    {
+        let result = self.document.transact_with(c, f)?;
+        if let Err(e) = self.after_transaction() {
+            return Err(TransactionError::PersisterError(e));
+        }
+        Ok(result)
+    }
+
+    /// Apply changes to this document.
+    pub fn apply_changes(
+        &mut self,
+        changes: impl IntoIterator<Item = Change>,
+    ) -> Result<(), Error<P::Error>> {
+        self.apply_changes_with::<_, ()>(changes, ApplyOptions::default())
+    }
+
+    pub fn apply_changes_with<I: IntoIterator<Item = Change>, Obs: OpObserver>(
+        &mut self,
+        changes: I,
+        options: ApplyOptions<Obs>,
+    ) -> Result<(), Error<P::Error>> {
+        let mut to_persist = vec![];
+        let result = self.document.apply_changes_with(
+            changes.into_iter().map(|change| {
+                to_persist.push((
                     change.actor_id().clone(),
                     change.seq,
                     change.raw_bytes().to_vec(),
-                )])
-                .expect("Failed to save change from transaction");
-        }
+                ));
+                change
+            }),
+            options,
+        )?;
+        self.persister
+            .insert_changes(to_persist)
+            .map_err(Error::PersisterError)?;
         Ok(result)
     }
 


### PR DESCRIPTION
Adds a filesystem persistence layer.

There are some particularities to it:
- It has both a sync and async interface for flushing. The latter is behind a feature flag.
- It only writes to disk when `flush`ed, else it's like the memory store (this is for performance reasons)
  - This is similar to the `sled` strategy

Along, I made changes to the main lib:
- Added `persister_mut()` (useful for the flushing I'm talking about)
- Added `transact_with()`
- Added `apply_changes` and `apply_changes_with`
- Changed the `reset_sync_state` logic to actually call the persister's function so it wouldn't only be removed from memory, but also from the store.

Happy to make changes! Let me know what you think.